### PR TITLE
Allow parameterless get methods

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flyacts-angular2-swagger-client-generator",
-  "version": "0.0.42",
+  "version": "0.0.43",
   "description": "Angular 2 API client generator from swagger json from Navid Nikpour (https://github.com/nvdnkpr/angular2-swagger-client-generator)",
   "homepage": "https://github.com/flyacts/angular2-swagger-client-generator",
   "main": "index.js",

--- a/templates/angular2-service.mustache
+++ b/templates/angular2-service.mustache
@@ -107,7 +107,7 @@ export class ApiClientService {
         let uri: string = `{{&backTickPath}}`;
 
         return this.http
-            .{{angular2httpMethod}}(this.domain + uri{{#hasPayload}}, JSON.stringify({{#parameters}}{{#isBodyParameter}}{{&camelCaseName}}{{/isBodyParameter}}{{/parameters}}){{/hasPayload}}{{#hasEmptyPayload}}, undefined{{/hasEmptyPayload}}, { headers: headers, search: queryParameters })
+            .{{angular2httpMethod}}(this.domain + uri{{#hasPayload}}, JSON.stringify({{#parameters}}{{#isBodyParameter}}{{&camelCaseName}}{{/isBodyParameter}}{{/parameters}}){{/hasPayload}}{{#hasEmptyPayload}}{{#isGet}}, undefined{{/isGet}}{{/hasEmptyPayload}}, { headers: headers, search: queryParameters })
             .map((res: Response) => {
                 return res;
             });


### PR DESCRIPTION
Make use of the existing `isGet` variable to remove the unnecessary `, undefined` that was inserted into the generated `http.get` call when no parameters were present in the swagger doc.

Example `paths` block that would fail before:
```
"paths": {
    "/health": {
      "get": {
        "tags": [
          "default-application-service"
        ],
        "summary": "health",
        "operationId": "healthUsingGET",
        "consumes": [
          "application/json"
        ],
        "produces": [
          "*/*"
        ],
        "responses": {
          "200": {
            "description": "OK",
            "schema": {
              "type": "integer",
              "format": "int32"
            }
          },
          "401": {
            "description": "Unauthorized"
          },
          "403": {
            "description": "Forbidden"
          },
          "404": {
            "description": "Not Found"
          }
        }
      }
    }
}
```